### PR TITLE
feat: add swag install and init

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,13 @@ runs:
       id: sonar-setup
       uses: variant-inc/actions-collection/sonar-setup@v2
 
+    - name: Install Swag and init
+      shell: bash
+      run: |
+        go install github.com/swaggo/swag/cmd/swag@latest
+        export PATH=$(go env GOPATH)/bin:$PATH
+        swag init
+
     - shell: bash
       run: |
         mkdir -p ./.github/workflows/actions-go/test


### PR DESCRIPTION
# Description

Add instalation of swag and swag init.
If there are swagger comments/annotations it creates proper files in docs folder which can be used by app to host Swagger UI.
[CLOUD-2654](https://usxpress.atlassian.net/browse/CLOUD-2654)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing
  functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Deployed lazy-go with it.
![image](https://github.com/user-attachments/assets/6db1e672-2ecc-4768-993b-c444e393f10a)
[GH action run](https://github.com/variant-inc/lazy-go/actions/runs/13052629171)
- [ ] Sanity Testing

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added documentation to test


[CLOUD-2654]: https://usxpress.atlassian.net/browse/CLOUD-2654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ